### PR TITLE
deviseのuserモデルに忘れていたカラムを追加

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :admins
   devise_for :users
+  devise_for :admins
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20230209072512_devise_create_users.rb
+++ b/db/migrate/20230209072512_devise_create_users.rb
@@ -32,8 +32,13 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.1]
       # t.string   :unlock_token # Only if unlock strategy is :email or :both
       # t.datetime :locked_at
 
+      ## 会員の名前（ニックネーム）を保存するカラム
+      t.string :name, null: false
+      ## 会員の退会機能用ステータスカラム、boolean型で真偽判別・デフォルトはfalseで設定しています。
+      t.boolean :status, null: false,  default: false
 
-      t.timestamps null: false
+      ## 会員の登録・更新日時がデフォルトでnowになるように設定しています。
+      t.timestamps null: false, default: ->{ "CURRENT_TIMESTAMP" }
     end
 
     add_index :users, :email,                unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_09_065542) do
+ActiveRecord::Schema.define(version: 2023_02_09_072512) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -58,6 +58,8 @@ ActiveRecord::Schema.define(version: 2023_02_09_065542) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
+    t.string "name", null: false
+    t.boolean "status", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
deviseのuserモデルに忘れていたカラムを追加しました。

一度migrateしてしまっていた古いuserモデルをdownにして、rails d devise userで関連ファイルを削除しています。
その後、再度userを作成し、必要なカラムを追加しました。
お手数お掛けし申し訳ありませんが、各自rails db:migrate:resetで新しいuserモデルの反映をお願いします。