### PR TITLE
postモデル内のカラム修正

### DIFF
--- a/db/migrate/20230210131338_create_posts.rb
+++ b/db/migrate/20230210131338_create_posts.rb
@@ -14,10 +14,10 @@ class CreatePosts < ActiveRecord::Migration[6.1]
       t.text :body, null: false
       ## 住所用カラム
       t.string :address, null: false
-      ## 郵便番号用カラム
-      t.string :postal_code, null: false
-      ## 座標用カラム
-      t.string :coordinate, null: false
+      ## 経度用カラム
+      t.float :longitude, null: false
+      ## 緯度用カラム
+      t.float :latitude, null: false
       ## アクセス方法用カラム
       t.text :access, null: false
       ## 設備用カラム

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -81,8 +81,8 @@ ActiveRecord::Schema.define(version: 2023_02_10_131858) do
     t.string "name", null: false
     t.text "body", null: false
     t.string "address", null: false
-    t.string "postal_code", null: false
-    t.string "coordinate", null: false
+    t.float "longitude", null: false
+    t.float "latitude", null: false
     t.text "access", null: false
     t.string "facility", null: false
     t.string "contact", null: false


### PR DESCRIPTION
postモデル内の座標カラムを、地図APIから座標を引っ張ってくるために経度と緯度カラムに修正しました。
また、郵便番号カラムが必要なかったので削除しております。
確認と反映をお願いします。